### PR TITLE
atualizção dos títulos de professora e doutora

### DIFF
--- a/UnB-CIC.cls
+++ b/UnB-CIC.cls
@@ -325,13 +325,18 @@
 %%
 %% --- Macros/comandos auxiliares ---
 %%
+%%
+%% --- Macros/comandos auxiliares ---
+%%
 \def\prof{\@ifnextchar[{\@prof@}{\@prof}}
 \def\@prof#1{Prof.\ #1}
 \def\@prof@[#1]#2{Prof.\nobreak\kern-.05em\textordfeminine\ #2}
 
 \def\dr{\@ifnextchar[{\@dr@}{\@dr}}
 \def\@dr#1{Dr.\ #1}
-\def\@dr@[#1]#2{Dr.\nobreak\kern-.05em\textordfeminine\ #2}
+\def\@dr@[#1]#2{Dr.a\nobreak\kern-.05em\ #2}
+
+%%
 
 %%
 %% --- Páginas do trabalho ---


### PR DESCRIPTION
de acordo com o VOLP, as reduções corretas para Doutora são Dr.a ou Dra, sem o superescrito.

Mais detalhes

http://www.academia.org.br/nossa-lingua/reducoes?sid=22
